### PR TITLE
SWE-agent[bot] PR to fix: 草稿箱页面样式优化 - 搜索框样式 - 草稿列表样式 - 草稿列表按钮样式

### DIFF
--- a/frontend/web/src/views/Drafts.vue
+++ b/frontend/web/src/views/Drafts.vue
@@ -392,19 +392,23 @@ onMounted(() => {
         width: 400px;
         
         :deep(.el-input__wrapper) {
-          border-radius: 24px;
-          padding: 8px 16px;
-          box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
-          transition: all 0.3s ease;
+          border-radius: 16px;
+          padding: 10px 18px;
+          box-shadow: 0 2px 12px rgba(0, 0, 0, 0.06);
+          transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
           background: rgba(255, 255, 255, 0.98);
+          border: 1px solid rgba(43, 88, 118, 0.08);
           
           &:hover {
-            box-shadow: 0 4px 12px rgba(0, 0, 0, 0.12);
+            box-shadow: 0 4px 16px rgba(0, 0, 0, 0.08);
+            border-color: rgba(43, 88, 118, 0.12);
+            background: rgba(255, 255, 255, 1);
           }
           
           &.is-focus {
-            box-shadow: 0 4px 16px rgba(43, 88, 118, 0.15);
-            border-color: rgba(43, 88, 118, 0.3);
+            box-shadow: 0 4px 20px rgba(43, 88, 118, 0.12);
+            border-color: rgba(43, 88, 118, 0.25);
+            background: rgba(255, 255, 255, 1);
           }
         }
         


### PR DESCRIPTION
This is a PR opened by AI tool [SWE Agent](https://github.com/SWE-agent/SWE-agent/) to close [#5](https://github.com/smartcat999/notex/issues/5) (草稿箱页面样式优化 - 搜索框样式 - 草稿列表样式 - 草稿列表按钮样式).

Closes #5.

<details>
<summary>Thought process ('trajectory') of SWE-agent (click to expand)</summary>

**🧑‍🚒 Response (0)**: 
I'll start by exploring the repository structure to understand the codebase and identify files related to the draft box (草稿箱) page styling.
**👀‍ Observation (0)**:
```
/smartcat999__notex/backend/templates/email/password_reset.html
/smartcat999__notex/backend/templates/email/verification.html
/smartcat999__notex/backend/templates/email/base.html
/smartcat999__notex/backend/templates/email/email_change.html
/smartcat999__notex/frontend/admin/vite.config.js
/smartcat999__notex/frontend/admin/src/stores/user.js
/smartcat999__notex/frontend/admin/src/api/auth.js
/smartcat999__notex/frontend/admin/src/utils/request.js
/smartcat999__notex/frontend/admin/src/router/index.js
/smartcat999__notex/frontend/admin/src/main.js
/smartcat999__notex/frontend/web/index.html
/smartcat999__notex/frontend/web/vite.config.js
/smartcat999__notex/frontend/web/src/stores/ai.js
/smartcat999__notex/frontend/web/src/stores/user.js
/smartcat999__notex/frontend/web/src/api/notification.js
/smartcat999__notex/frontend/web/src/api/auth.js
/smartcat999__notex/frontend/web/src/api/settings.js
/smartcat999__notex/frontend/web/src/api/drafts.js
/smartcat999__notex/frontend/web/src/api/posts.js
/smartcat999__notex/frontend/web/src/api/user.js
/smartcat999__notex/frontend/web/src/utils/date.js
/smartcat999__notex/frontend/web/src/utils/time.js
/smartcat999__notex/frontend/web/src/utils/request.js
/smartcat999__notex/frontend/web/src/utils/upload.js
/smartcat999__notex/frontend/web/src/router/index.js
/smartcat999__notex/frontend/web/src/services/aiService.js
/smartcat999__notex/frontend/web/src/main.js
```

---

**🧑‍🚒 Response (1)**: 

**👀‍ Observation (1)**:
```
Here's the files and directories up to 2 levels deep in /smartcat999__notex, excluding hidden items:
/smartcat999__notex
/smartcat999__notex/package-lock.json
/smartcat999__notex/README.md
/smartcat999__notex/README_SWE_AGENT.md
/smartcat999__notex/docker-compose.yml
/smartcat999__notex/backend
/smartcat999__notex/backend/api
/smartcat999__notex/backend/locales
/smartcat999__notex/backend/model
/smartcat999__notex/backend/middleware
/smartcat999__notex/backend/config.example.yaml
/smartcat999__notex/backend/migrations
/smartcat999__notex/backend/scripts
/smartcat999__notex/backend/go.sum
/smartcat999__notex/backend/main.go
/smartcat999__notex/backend/pkg
/smartcat999__notex/backend/config
/smartcat999__notex/backend/templates
/smartcat999__notex/backend/go.mod
/smartcat999__notex/package.json
/smartcat999__notex/frontend
/smartcat999__notex/frontend/admin
/smartcat999__notex/frontend/web
```

---

**🧑‍🚒 Response (2)**: 
The PR description mentions optimizing the draft box (草稿箱) page styling, specifically:
- Search box style
- Draft list style  
- Draft list button style

Let me look for draft-related files in the frontend:
**👀‍ Observation (2)**:
```
/smartcat999__notex/frontend/web/src/api/drafts.js
/smartcat999__notex/frontend/web/src/views/Drafts.vue
```

---

**🧑‍🚒 Response (3)**: 
Perfect! Let me examine the Drafts.vue file which is likely the draft box page:
**👀‍ Observation (3)**:
```
Here's the result of running `cat -n` on /smartcat999__notex/frontend/web/src/views/Drafts.vue:
     1	<template>
     2	  <div class="drafts-container">
     3	    <div class="page-header">
     4	      <h1>草稿箱</h1>
     5	      <div class="header-actions">
     6	        <el-input
     7	          v-model="searchQuery"
     8	          placeholder="搜索草稿..."
     9	          @input="handleSearch"
    10	          clearable
    11	        >
    12	          <template #prefix>
    13	            <el-icon><Search /></el-icon>
    14	          </template>
    15	        </el-input>
    16	      </div>
    17	    </div>
    18	
    19	    <div class="drafts-list" v-loading="loading">
    20	      <template v-if="drafts.length > 0">
    21	        <div v-for="draft in drafts" :key="draft.id" class="draft-card">
    22	          <div class="draft-header">
    23	            <h2 class="draft-title">
    24	              <a :href="draft.url" target="_blank">{{ draft.title || '无标题草稿' }}</a>
    25	            </h2>
    26	            <div class="draft-actions">
    27	              <el-button type="info" plain @click="handlePreview(draft)">
    28	                <el-icon><View /></el-icon>
    29	                预览
    30	              </el-button>
    31	              <el-button type="primary" @click="handleEdit(draft)">编辑</el-button>
    32	              <el-button type="success" @click="handlePublish(draft)">发布</el-button>
    33	              <el-button type="danger" @click="handleDelete(draft)">删除</el-button>
    34	            </div>
    35	          </div>
    36	          <div class="draft-meta">
    37	            <span class="draft-date">最后编辑: {{ formatDate(draft.updated_at) }}</span>
    38	            <span class="draft-category" v-if="draft.category">
    39	              {{ draft.category }}
    40	            </span>
    41	          </div>
    42	          <p class="draft-summary">{{ draft.summary || '暂无摘要' }}</p>
    43	          <div class="draft-footer">
    44	            <div class="draft-tags">
    45	              <el-tag v-for="tag in draft.tags" :key="tag" :type="tag.type" :effect="tag.effect">
    46	                {{ tag.name }}
    47	              </el-tag>
    48	            </div>
    49	          </div>
    50	        </div>
    51	      </template>
    52	      <el-empty v-else description="暂无草稿" />
    53	    </div>
    54	
    55	    <div class="pagination" v-if="total > 0">
    56	      <el-pagination
    57	        v-model:current-page="currentPage"
    58	        v-model:page-size="pageSize"
    59	        :total="total"
    60	        :page-sizes="[10, 20, 30, 50]"
    61	        layout="total, sizes, prev, pager, next"
    62	        @size-change="handleSizeChange"
    63	        @current-change="handleCurrentChange"
    64	      />
    65	    </div>
    66	
    67	    <!-- 预览对话框 -->
    68	    <el-dialog
    69	      v-model="previewDialogVisible"
    70	      title="文章预览"
    71	      width="800px"
    72	      :close-on-click-modal="false"
    73	      class="preview-dialog"
    74	      destroy-on-close
    75	      fullscreen
    76	    >
    77	      <div class="preview-content" ref="previewContentRef">
    78	        <div class="post-header" :class="{ 'no-cover': !currentDraft?.cover }">
    79	          <div class="post-cover" v-if="currentDraft?.cover">
    80	            <img :src="currentDraft.cover" :alt="currentDraft.title">
    81	          </div>
    82	          <div class="header-content">
    83	            <h1>{{ currentDraft?.title || '无标题草稿' }}</h1>
    84	            <div class="post-meta">
    85	              <span>
    86	                <el-icon><Calendar /></el-icon>
    87	                {{ formatDate(currentDraft?.updated_at) }}
    88	              </span>
    89	              <span>
    90	                <el-icon><View /></el-icon>
    91	                0
    92	              </span>
    93	              <span>
    94	                <el-icon><ChatDotRound /></el-icon>
    95	                0
    96	              </span>
    97	            </div>
    98	            <!-- 作者信息 -->
    99	            <AuthorCard :author="userStore.user" />
   100	            <div v-if="currentDraft?.tags?.length" class="post-tags">
   101	              <el-tag
   102	                v-for="tag in currentDraft.tags"
   103	                :key="tag.id"
   104	                size="small"
   105	                class="tag"
   106	              >
   107	                {{ tag.name }}
   108	              </el-tag>
   109	            </div>
   110	          </div>
   111	        </div>
   112	
   113	        <div class="post-content markdown-body">
   114	          <MarkdownPreview :content="currentDraft?.content" />
   115	        </div>
   116	      </div>
   117	      <template #footer>
   118	        <div class="dialog-footer">
   119	          <el-button @click="previewDialogVisible = false">关闭</el-button>
   120	        </div>
   121	      </template>
   122	    </el-dialog>
   123	  </div>
   124	</template>
   125	
   126	<script setup>
   127	import { ref, onMounted, nextTick, watch } from 'vue'
   128	import { useRouter } from 'vue-router'
   129	import { ElMessage, ElMessageBox } from 'element-plus'
   130	import { Search, View, Calendar, ChatDotRound } from '@element-plus/icons-vue'
   131	import { getDrafts, deleteDraft, publishDraft, getDraft } from '@/api/drafts'
   132	import { formatDate } from '@/utils/date'
   133	import { useUserStore } from '@/stores/user'
   134	import MarkdownPreview from '@/components/MarkdownPreview.vue'
   135	import AuthorCard from '@/components/AuthorCard.vue'
   136	import hljs from 'highlight.js'
   137	import 'highlight.js/styles/github.css'
   138	
   139	const router = useRouter()
   140	const userStore = useUserStore()
   141	const loading = ref(false)
   142	const drafts = ref([])
   143	const total = ref(0)
   144	const currentPage = ref(1)
   145	const pageSize = ref(10)
   146	const searchQuery = ref('')
   147	const searchTimeout = ref(null)
   148	const previewDialogVisible = ref(false)
   149	const currentDraft = ref(null)
   150	const previewContentRef = ref(null)
   151	
   152	const fetchDrafts = async () => {
   153	  loading.value = true
   154	  try {
   155	    const response = await getDrafts({
   156	      page: currentPage.value,
   157	      page_size: pageSize.value,
   158	      search: searchQuery.value
   159	    })
   160	    drafts.value = response.items || []
   161	    total.value = response.total || 0
   162	  } catch (error) {
   163	    console.error('Failed to fetch drafts:', error)
   164	    ElMessage.error('获取草稿列表失败')
   165	  } finally {
   166	    loading.value = false
   167	  }
   168	}
   169	
   170	const handleSearch = () => {
   171	  if (searchTimeout.value) {
   172	    clearTimeout(searchTimeout.value)
   173	  }
   174	  searchTimeout.value = setTimeout(() => {
   175	    currentPage.value = 1
   176	    fetchDrafts()
   177	  }, 300)
   178	}
   179	
   180	const handleSizeChange = (size) => {
   181	  pageSize.value = size
   182	  fetchDrafts()
   183	}
   184	
   185	const handleCurrentChange = (page) => {
   186	  currentPage.value = page
   187	  fetchDrafts()
   188	}
   189	
   190	const handleEdit = (draft) => {
   191	  router.push({
   192	    name: 'NewPost',
   193	    query: { draft_id: draft.id }
   194	  })
   195	}
   196	
   197	const handlePublish = async (draft) => {
   198	  try {
   199	    await ElMessageBox.confirm('确定要发布这篇草稿吗？', '提示', {
   200	      confirmButtonText: '确定',
   201	      cancelButtonText: '取消',
   202	      type: 'warning'
   203	    })
   204	    
   205	    await publishDraft(draft.id)
   206	    ElMessage.success('发布成功')
   207	    fetchDrafts()
   208	  } catch (error) {
   209	    if (error !== 'cancel') {
   210	      console.error('Failed to publish draft:', error)
   211	      ElMessage.error('发布失败')
   212	    }
   213	  }
   214	}
   215	
   216	const handleDelete = async (draft) => {
   217	  try {
   218	    await ElMessageBox.confirm('确定要删除这篇草稿吗？此操作不可恢复！', '警告', {
   219	      confirmButtonText: '确定',
   220	      cancelButtonText: '取消',
   221	      type: 'warning'
   222	    })
   223	    
   224	    await deleteDraft(draft.id)
   225	    ElMessage.success('删除成功')
   226	    fetchDrafts()
   227	  } catch (error) {
   228	    if (error !== 'cancel') {
   229	      console.error('Failed to delete draft:', error)
   230	      ElMessage.error('删除失败')
   231	    }
   232	  }
   233	}
   234	
   235	const handlePreview = async (draft) => {
   236	  try {
   237	    const draftDetail = await getDraft(draft.id)
   238	    currentDraft.value = draftDetail
   239	    previewDialogVisible.value = true
   240	    nextTick(() => {
   241	      updateCodeSections()
   242	    })
   243	  } catch (error) {
   244	    console.error('Failed to load draft for preview:', error)
   245	    ElMessage.error('加载预览失败')
   246	  }
   247	}
   248	
   249	// 更新代码块位置和样式
   250	const updateCodeSections = () => {
   251	  nextTick(() => {
   252	    const previewElement = document.querySelector('.preview-dialog .post-content')
   253	    if (!previewElement) return
   254	    
   255	    const pres = previewElement.querySelectorAll('pre')
   256	    pres.forEach(pre => {
   257	      // Skip if already processed
   258	      if (pre.querySelector('.pre-wrapper')) return
   259	      
   260	      const code = pre.querySelector('code')
   261	      
   262	      // 创建包装容器
   263	      const wrapper = document.createElement('div')
   264	      wrapper.className = 'pre-wrapper'
   265	      
   266	      // 移动代码到包装容器
   267	      if (code) {
   268	        pre.removeChild(code)
   269	        wrapper.appendChild(code)
   270	      }
   271	      pre.appendChild(wrapper)
   272	
   273	      // 添加语言标签
   274	      if (!pre.querySelector('.language-label') && pre.hasAttribute('data-language')) {
   275	        const languageLabel = document.createElement('span')
   276	        languageLabel.className = 'language-label'
   277	        languageLabel.textContent = pre.getAttribute('data-language')
   278	        pre.appendChild(languageLabel)
   279	      }
   280	
   281	      // 添加复制按钮
   282	      if (!pre.querySelector('.copy-button')) {
   283	        const button = document.createElement('button')
   284	        button.className = 'copy-button'
   285	        button.innerHTML = `
   286	          <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
   287	            <rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect>
   288	            <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path>
   289	          </svg>
   290	          复制
   291	        `
   292	        button.addEventListener('click', () => {
   293	          const text = code.textContent
   294	          navigator.clipboard.writeText(text).then(() => {
   295	            button.innerHTML = `
   296	              <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
   297	                <polyline points="20 6 9 17 4 12"></polyline>
   298	              </svg>
   299	              已复制
   300	            `
   301	            button.classList.add('copied')
   302	            setTimeout(() => {
   303	              button.innerHTML = `
   304	                <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
   305	                  <rect x="9" y="9" width="13" height="13" rx="2" ry="2"></rect>
   306	                  <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"></path>
   307	                </svg>
   308	                复制
   309	              `
   310	              button.classList.remove('copied')
   311	            }, 2000)
   312	          }).catch(() => {
   313	            ElMessage.error('复制失败')
   314	          })
   315	        })
   316	        pre.appendChild(button)
   317	      }
   318	    })
   319	  })
   320	}
   321	
   322	// Watch for dialog visibility changes
   323	watch(previewDialogVisible, (newValue) => {
   324	  if (newValue === true) {
   325	    // When dialog becomes visible, update code sections after DOM update
   326	    nextTick(() => {
   327	      updateCodeSections()
   328	    })
   329	  }
   330	})
   331	
   332	onMounted(() => {
   333	  fetchDrafts()
   334	  updateCodeSections()
   335	})
   336	</script>
   337	
   338	<style lang="scss" scoped>
   339	@import '@/styles/post-content.scss';
   340	
   341	.drafts-container {
   342	  max-width: 900px;
   343	  margin: 32px auto;
   344	  padding: 0 20px;
   345	
   346	  .page-header {
   347	    margin-bottom: 32px;
   348	    text-align: center;
   349	
   350	    h1 {
   351	      margin: 0 0 16px;
   352	      font-size: 2.2em;
   353	      font-weight: 700;
   354	      background: linear-gradient(135deg, #2B5876, #4E4376);
   355	      -webkit-background-clip: text;
   356	      -webkit-text-fill-color: transparent;
   357	      letter-spacing: 0.02em;
   358	      position: relative;
   359	      display: inline-block;
   360	
   361	      &::after {
   362	        content: '';
   363	        position: absolute;
   364	        bottom: 4px;
   365	        left: -8px;
   366	        right: -8px;
   367	        height: 12px;
   368	        background-color: rgba(43, 88, 118, 0.15);
   369	        border-radius: 6px;
   370	        z-index: -1;
   371	        transform: skew(-12deg);
   372	      }
   373	    }
   374	
   375	    .header-actions {
   376	      display: flex;
   377	      justify-content: center;
   378	      gap: 16px;
   379	      margin-top: 24px;
   380	
   381	      .action-button {
   382	        padding: 12px 24px;
   383	        border-radius: 8px;
   384	        transition: all 0.3s ease;
   385	        background: linear-gradient(135deg, #2B5876, #4E4376);
   386	        color: white;
   387	        border: none;
   388	        display: flex;
   389	        align-items: center;
   390	        gap: 8px;
   391	        font-size: 1em;
   392	
   393	        &:hover {
   394	          transform: translateY(-2px);
   395	          box-shadow: 0 4px 12px rgba(43, 88, 118, 0.2);
   396	        }
   397	
   398	        .el-icon {
   399	          font-size: 1.2em;
   400	        }
   401	      }
   402	    }
   403	  }
   404	
   405	  .drafts-list {
   406	    .draft-card {
   407	      background: rgba(255, 255, 255, 0.98);
   408	      border-radius: 12px;
   409	      box-shadow: 0 2px 12px rgba(0, 0, 0, 0.05);
   410	      padding: 24px;
   411	      margin-bottom: 20px;
   412	      transition: all 0.3s ease;
   413	
   414	      &:hover {
   415	        transform: translateY(-2px);
   416	        box-shadow: 0 6px 20px rgba(0, 0, 0, 0.08);
   417	        background: rgba(255, 255, 255, 1);
   418	      }
   419	
   420	      .draft-header {
   421	        display: flex;
   422	        justify-content: space-between;
   423	        align-items: flex-start;
   424	        margin-bottom: 16px;
   425	
   426	        .draft-title {
   427	          margin: 0;
   428	          font-size: 1.3em;
   429	          font-weight: 600;
   430	          color: #2c3e50;
   431	
   432	          a {
   433	            color: inherit;
   434	            text-decoration: none;
   435	            transition: all 0.3s ease;
   436	
   437	            &:hover {
   438	              color: #2B5876;
   439	              text-shadow: 0 0 1px rgba(43, 88, 118, 0.15);
   440	            }
   441	          }
   442	        }
   443	
   444	        .draft-actions {
   445	          display: flex;
   446	          gap: 12px;
   447	
   448	          .el-button {
   449	            padding: 8px 16px;
   450	            border: none;
   451	            transition: all 0.3s ease;
   452	            font-weight: 500;
   453	            font-size: 0.95em;
   454	
   455	            &.el-button--primary {
   456	              background: linear-gradient(135deg, #2B5876, #4E4376);
   457	              color: white;
   458	
   459	              &:hover {
   460	                transform: translateY(-1px);
   461	                box-shadow: 0 4px 12px rgba(43, 88, 118, 0.2);
   462	              }
   463	            }
   464	
   465	            &.el-button--success {
   466	              background: linear-gradient(135deg, #2ecc71, #27ae60);
   467	              color: white;
   468	
   469	              &:hover {
   470	                transform: translateY(-1px);
   471	                box-shadow: 0 4px 12px rgba(46, 204, 113, 0.2);
   472	              }
   473	            }
   474	
   475	            &.el-button--danger {
   476	              background: linear-gradient(135deg, #e74c3c, #c0392b);
   477	              color: white;
   478	
   479	              &:hover {
   480	                transform: translateY(-1px);
   481	                box-shadow: 0 4px 12px rgba(231, 76, 60, 0.2);
   482	              }
   483	            }
   484	          }
   485	        }
   486	      }
   487	
   488	      .draft-meta {
   489	        display: flex;
   490	        align-items: center;
   491	        gap: 16px;
   492	        color: #718096;
   493	        font-size: 0.9em;
   494	        margin-bottom: 12px;
   495	
   496	        .meta-item {
   497	          display: flex;
   498	          align-items: center;
   499	          gap: 6px;
   500	
   501	          .el-icon {
   502	            font-size: 1.1em;
   503	            opacity: 0.85;
   504	          }
   505	        }
   506	      }
   507	
   508	      .draft-summary {
   509	        color: #4a5568;
   510	        font-size: 0.95em;
   511	        line-height: 1.6;
   512	        margin: 0;
   513	        display: -webkit-box;
   514	        -webkit-line-clamp: 2;
   515	        -webkit-box-orient: vertical;
   516	        overflow: hidden;
   517	      }
   518	
   519	      .draft-footer {
   520	        margin-top: 16px;
   521	        padding-top: 16px;
   522	        border-top: 1px solid rgba(0, 0, 0, 0.04);
   523	
   524	        .draft-tags {
   525	          display: flex;
   526	          gap: 8px;
   527	          flex-wrap: wrap;
   528	
   529	          .el-tag {
   530	            background: rgba(43, 88, 118, 0.06);
   531	            border: none;
   532	            color: #2B5876;
   533	            transition: all 0.3s ease;
   534	
   535	            &:hover {
   536	              background: rgba(43, 88, 118, 0.1);
   537	              transform: translateY(-1px);
   538	            }
   539	          }
   540	        }
   541	      }
   542	    }
   543	  }
   544	
   545	  .empty-state {
   546	    text-align: center;
   547	    padding: 60px 20px;
   548	    background: rgba(43, 88, 118, 0.03);
   549	    border-radius: 16px;
   550	    margin-top: 32px;
   551	
   552	    .empty-icon {
   553	      font-size: 3em;
   554	      color: #2B5876;
   555	      margin-bottom: 16px;
   556	      opacity: 0.5;
   557	    }
   558	
   559	    .empty-text {
   560	      color: #4a5568;
   561	      font-size: 1.1em;
   562	      margin-bottom: 24px;
   563	    }
   564	
   565	    .create-button {
   566	      background: linear-gradient(135deg, #2B5876, #4E4376);
   567	      color: white;
   568	      border: none;
   569	      padding: 12px 28px;
   570	      border-radius: 8px;
   571	      font-size: 1em;
   572	      transition: all 0.3s ease;
   573	
   574	      &:hover {
   575	        transform: translateY(-2px);
   576	        box-shadow: 0 4px 12px rgba(43, 88, 118, 0.2);
   577	      }
   578	
   579	      .el-icon {
   580	        margin-right: 8px;
   581	      }
   582	    }
   583	  }
   584	
   585	  .pagination {
   586	    margin-top: 24px;
   587	    display: flex;
   588	    justify-content: center;
   589	  }
   590	}
   591	
   592	@media (max-width: 768px) {
   593	  .page-header {
   594	    flex-direction: column;
   595	   <response clipped><NOTE>To save on context only part of this file has been shown to you. You should retry this tool after you have searched inside the file with `grep -n` in order to find the line numbers of what you are looking for.</NOTE>
```

---

**🧑‍🚒 Response (4)**: 
Let me see the rest of the file:
**👀‍ Observation (4)**:
```
Here's the result of running `cat -n` on /smartcat999__notex/frontend/web/src/views/Drafts.vue:
   590	}
   591	
   592	@media (max-width: 768px) {
   593	  .page-header {
   594	    flex-direction: column;
   595	    align-items: stretch;
   596	    gap: 16px;
   597	  }
   598	
   599	  .header-actions {
   600	    width: 100%;
   601	    justify-content: flex-end;
   602	  }
   603	
   604	  .draft-card {
   605	    flex-direction: column;
   606	  }
   607	
   608	  .draft-header {
   609	    flex-direction: column;
   610	    align-items: stretch;
   611	    gap: 16px;
   612	  }
   613	
   614	  .draft-actions {
   615	    width: 100%;
   616	    justify-content: flex-end;
   617	  }
   618	}
   619	
   620	.preview-dialog {
   621	  :deep(.el-dialog__body) {
   622	    padding: 0;
   623	  }
   624	
   625	  .preview-content {
   626	    max-width: 900px;
   627	    margin: 0 auto;
   628	    padding: 40px 20px;
   629	
   630	    .post-header {
   631	      position: relative;
   632	      margin-bottom: 40px;
   633	      text-align: center;
   634	      padding: 40px;
   635	      border-radius: 16px;
   636	      background: linear-gradient(135deg, rgba(43, 88, 118, 0.04) 0%, rgba(78, 67, 118, 0.04) 100%);
   637	      backdrop-filter: blur(8px);
   638	      transition: all 0.3s ease;
   639	
   640	      &.no-cover {
   641	        padding-top: 0;
   642	
   643	        .header-content {
   644	          margin-top: 0;
   645	        }
   646	      }
   647	
   648	      .post-cover {
   649	        margin: -40px -40px 30px;
   650	        height: 360px;
   651	        border-radius: 16px 16px 0 0;
   652	        overflow: hidden;
   653	        position: relative;
   654	
   655	        &::after {
   656	          content: '';
   657	          position: absolute;
   658	          left: 0;
   659	          right: 0;
   660	          bottom: 0;
   661	          height: 160px;
   662	          background: linear-gradient(to bottom, transparent, rgba(0, 0, 0, 0.6));
   663	        }
   664	
   665	        img {
   666	          width: 100%;
   667	          height: 100%;
   668	          object-fit: cover;
   669	        }
   670	      }
   671	
   672	      .header-content {
   673	        position: relative;
   674	        z-index: 1;
   675	
   676	        h1 {
   677	          font-size: 2.4em;
   678	          font-weight: 700;
   679	          color: #1a202c;
   680	          margin: 0 0 20px;
   681	          line-height: 1.3;
   682	          letter-spacing: -0.02em;
   683	          background: linear-gradient(135deg, #2B5876 0%, #4E4376 100%);
   684	          -webkit-background-clip: text;
   685	          -webkit-text-fill-color: transparent;
   686	        }
   687	      }
   688	
   689	      .post-meta {
   690	        width: 100%;
   691	        color: #6b7280;
   692	        font-size: 0.9em;
   693	        margin-bottom: 24px;
   694	        display: flex;
   695	        justify-content: center;
   696	        flex-wrap: wrap;
   697	        gap: 16px;
   698	
   699	        span {
   700	          display: inline-flex;
   701	          align-items: center;
   702	          gap: 8px;
   703	          padding: 6px 12px;
   704	          background: rgba(43, 88, 118, 0.06);
   705	          border-radius: 20px;
   706	          transition: all 0.3s ease;
   707	
   708	          &:hover {
   709	            background: rgba(43, 88, 118, 0.1);
   710	            transform: translateY(-1px);
   711	          }
   712	
   713	          .el-icon {
   714	            font-size: 1.1em;
   715	            color: #2B5876;
   716	          }
   717	        }
   718	      }
   719	
   720	      .post-tags {
   721	        display: flex;
   722	        justify-content: center;
   723	        flex-wrap: wrap;
   724	        gap: 8px;
   725	        margin-top: 20px;
   726	
   727	        .tag {
   728	          background: rgba(43, 88, 118, 0.06);
   729	          border: none;
   730	          color: #2B5876;
   731	          transition: all 0.3s ease;
   732	          font-size: 0.85em;
   733	          padding: 0 12px;
   734	          height: 24px;
   735	          line-height: 24px;
   736	          border-radius: 12px;
   737	
   738	          &:hover {
   739	            background: rgba(43, 88, 118, 0.1);
   740	            transform: translateY(-1px);
   741	          }
   742	        }
   743	      }
   744	
   745	      :deep(.author-card) {
   746	        width: 100%;
   747	        margin: 0 0 24px;
   748	        display: flex;
   749	        justify-content: center;
   750	        border: none;
   751	        padding: 0;
   752	
   753	        .author-content {
   754	          background: rgba(43, 88, 118, 0.03);
   755	          padding: 12px 20px;
   756	          border-radius: 16px;
   757	          transition: all 0.3s ease;
   758	
   759	          &:hover {
   760	            background: rgba(43, 88, 118, 0.06);
   761	            transform: translateY(-1px);
   762	          }
   763	        }
   764	      }
   765	    }
   766	
   767	    .post-content {
   768	      background: #fff;
   769	      border-radius: 16px;
   770	      padding: 40px;
   771	      box-shadow: 0 4px 20px rgba(0, 0, 0, 0.05);
   772	      
   773	      /* Headings */
   774	      :deep(h1), :deep(h2), :deep(h3), :deep(h4), :deep(h5), :deep(h6) {
   775	        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
   776	        margin: 1.8em 0 0.9em;
   777	        font-weight: 600;
   778	        line-height: 1.3;
   779	        color: #1f2937;
   780	        padding: 0;
   781	        background: transparent;
   782	        box-shadow: none;
   783	        border-radius: 0;
   784	        border-left: none;
   785	        position: relative;
   786	
   787	        &:first-child {
   788	          margin-top: 0.5em;
   789	        }
   790	      }
   791	
   792	      :deep(h1) {
   793	        font-size: 2.2em;
   794	        color: #1a365d;
   795	        margin: 1.2em 0 0.8em;
   796	        position: relative;
   797	        font-weight: 700;
   798	        padding-bottom: 0.5em;
   799	        border-bottom: 2px solid rgba(26, 54, 93, 0.1);
   800	
   801	        &::after {
   802	          content: '';
   803	          position: absolute;
   804	          bottom: -2px;
   805	          left: 0;
   806	          width: 80px;
   807	          height: 2px;
   808	          background: linear-gradient(90deg, #1a365d, rgba(26, 54, 93, 0.1));
   809	          border-radius: 2px;
   810	        }
   811	      }
   812	
   813	      :deep(h2) {
   814	        font-size: 1.7em;
   815	        color: #2d4a6d;
   816	        margin: 1.8em 0 0.8em;
   817	        position: relative;
   818	        font-weight: 600;
   819	        padding-bottom: 0.5em;
   820	        border-bottom: 1px solid rgba(45, 74, 109, 0.1);
   821	
   822	        &::after {
   823	          content: '';
   824	          position: absolute;
   825	          bottom: -1px;
   826	          left: 0;
   827	          width: 60px;
   828	          height: 1px;
   829	          background: linear-gradient(90deg, rgba(45, 74, 109, 0.8), rgba(45, 74, 109, 0.1));
   830	          border-radius: 1px;
   831	        }
   832	      }
   833	
   834	      :deep(h3) {
   835	        font-size: 1.4em;
   836	        color: #34557a;
   837	        margin: 1.5em 0 0.8em;
   838	        position: relative;
   839	        padding-left: 1em;
   840	        font-weight: 600;
   841	
   842	        &::before {
   843	          content: '';
   844	          position: absolute;
   845	          left: 0;
   846	          top: 0.2em;
   847	          bottom: 0.2em;
   848	          width: 3px;
   849	          background: linear-gradient(180deg, #34557a, rgba(52, 85, 122, 0.2));
   850	          border-radius: 1.5px;
   851	        }
   852	      }
   853	      
   854	      :deep(h4) {
   855	        font-size: 1.2em;
   856	        color: #3d5a7a;
   857	        margin: 1.2em 0 0.6em;
   858	        font-weight: 600;
   859	      }
   860	
   861	      :deep(h5) {
   862	        font-size: 1.1em;
   863	        color: #456789;
   864	        margin: 1em 0 0.5em;
   865	        font-weight: 500;
   866	      }
   867	
   868	      :deep(h6) {
   869	        font-size: 1em;
   870	        color: #516b88;
   871	        margin: 1em 0 0.5em;
   872	        font-weight: 500;
   873	      }
   874	      
   875	      /* Paragraphs */
   876	      :deep(p) {
   877	        margin: 1em 0;
   878	        line-height: 1.8;
   879	        color: #2c3e50;
   880	      }
   881	
   882	      :deep(ol),
   883	      :deep(ul) {
   884	        line-height: 1.6;
   885	        margin: 1em 0;
   886	        padding-left: 1.5em;
   887	
   888	        li {
   889	          margin: 0.5em 0;
   890	          padding-left: 0.2em;
   891	          line-height: 1.6;
   892	          color: #2c3e50;
   893	
   894	          &::marker {
   895	            color: #2B5876;
   896	          }
   897	
   898	          p {
   899	            margin: 0;
   900	            line-height: 1.6;
   901	          }
   902	        }
   903	      }
   904	
   905	      :deep(pre) {
   906	        background: #f8fafc;
   907	        border-radius: 8px;
   908	        padding: 16px;
   909	        margin: 1.5em 0;
   910	        position: relative;
   911	        border: 1px solid #e2e8f0;
   912	
   913	        .pre-wrapper {
   914	          overflow-x: auto;
   915	          position: relative;
   916	
   917	          &::-webkit-scrollbar {
   918	            height: 8px;
   919	            background-color: transparent;
   920	          }
   921	
   922	          &::-webkit-scrollbar-thumb {
   923	            background: #cbd5e0;
   924	            border-radius: 4px;
   925	            
   926	            &:hover {
   927	              background: #a0aec0;
   928	            }
   929	          }
   930	
   931	          &::-webkit-scrollbar-track {
   932	            background: transparent;
   933	            border-radius: 4px;
   934	          }
   935	        }
   936	
   937	        code {
   938	          padding-right: 85px;
   939	          display: inline-block;
   940	          min-width: 100%;
   941	          font-family: ui-monospace, SFMono-Regular, SF Mono, Menlo, Consolas, Liberation Mono, monospace;
   942	          font-size: 0.9em;
   943	          line-height: 1.5;
   944	          tab-size: 2;
   945	        }
   946	
   947	        .copy-button {
   948	          position: absolute;
   949	          top: 6px;
   950	          right: 6px;
   951	          height: 24px;
   952	          min-width: 70px;
   953	          padding: 0 10px;
   954	          font-size: 0.75em;
   955	          color: #64748b;
   956	          background: #f8fafc;
   957	          border: 1px solid #e2e8f0;
   958	          border-radius: 6px;
   959	          cursor: pointer;
   960	          transition: all 0.2s cubic-bezier(0.4, 0, 0.2, 1);
   961	          display: inline-flex;
   962	          align-items: center;
   963	          justify-content: center;
   964	          gap: 4px;
   965	          opacity: 0;
   966	          transform: translateY(-4px);
   967	          z-index: 3;
   968	          font-family: system-ui, -apple-system, sans-serif;
   969	          font-weight: 500;
   970	          box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
   971	          backdrop-filter: blur(8px);
   972	          overflow: hidden;
   973	          text-overflow: ellipsis;
   974	          white-space: nowrap;
   975	
   976	          svg {
   977	            width: 12px;
   978	            height: 12px;
   979	            stroke: currentColor;
   980	            stroke-width: 2;
   981	            transition: all 0.2s ease;
   982	            flex-shrink: 0;
   983	          }
   984	
   985	          span {
   986	            white-space: nowrap;
   987	            overflow: hidden;
   988	            text-overflow: ellipsis;
   989	          }
   990	
   991	          &:hover {
   992	            background: #f1f5f9;
   993	            color: #0f172a;
   994	            border-color: #cbd5e0;
   995	            box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05),
   996	                       0 1px 2px rgba(0, 0, 0, 0.1);
   997	            transform: translateY(0);
   998	          }
   999	
  1000	          &:active {
  1001	            transform: translateY(0) scale(0.96);
  1002	            background: #e2e8f0;
  1003	          }
  1004	
  1005	          &.copied {
  1006	            background: #2B5876;
  1007	            color: white;
  1008	            border-color: #1a365d;
  1009	            box-shadow: 0 1px 3px rgba(43, 88, 118, 0.2);
  1010	
  1011	            svg {
  1012	              stroke: white;
  1013	            }
  1014	
  1015	            &:hover {
  1016	              background: #34557a;
  1017	              border-color: #2B5876;
  1018	              box-shadow: 0 2px 4px rgba(43, 88, 118, 0.2),
  1019	                         0 1px 2px rgba(43, 88, 118, 0.1);
  1020	            }
  1021	          }
  1022	        }
  1023	
  1024	        &:hover {
  1025	          .copy-button {
  1026	            opacity: 1;
  1027	            transform: translateY(0);
  1028	          }
  1029	        }
  1030	
  1031	        /* Replace ::before with a language-label element */
  1032	        &[data-language]::before {
  1033	          display: none;
  1034	        }
  1035	        
  1036	        .language-label {
  1037	          position: absolute;
  1038	          top: 8px;
  1039	          left: 16px;
  1040	          font-size: 0.7em;
  1041	          color: #64748b;
  1042	          font-weight: 500;
  1043	          text-transform: uppercase;
  1044	          letter-spacing: 0.05em;
  1045	          background: #f1f5f9;
  1046	          padding: 2px 8px;
  1047	          border-radius: 4px;
  1048	          border: 1px solid #e2e8f0;
  1049	          z-index: 2;
  1050	          display: inline-flex;
  1051	          align-items: center;
  1052	          justify-content: center;
  1053	        }
  1054	      }
  1055	
  1056	      :deep(code:not(pre code)) {
  1057	        padding: 0.2em 0.4em;
  1058	        margin: 0;
  1059	        font-size: 0.85em;
  1060	        background: rgba(43, 88, 118, 0.06);
  1061	        border-radius: 3px;
  1062	        font-family: ui-monospace, SFMono-Regular, SF Mono, Menlo, Consolas, Liberation Mono, monospace;
  1063	        color: #2B5876;
  1064	      }
  1065	      
  1066	      :deep(blockquote) {
  1067	        margin: 1.5em 0;
  1068	        padding: 1em 1.5em;
  1069	        border-left: 4px solid #2d4a6d;
  1070	        background: rgba(45, 74, 109, 0.03);
  1071	        border-radius: 0 8px 8px 0;
  1072	        color: #4a5568;
  1073	
  1074	        p {
  1075	          margin: 0;
  1076	        }
  1077	      }
  1078	      
  1079	      :deep(table) {
  1080	        width: 100%;
  1081	        margin: 1.5em 0;
  1082	        border-collapse: collapse;
  1083	        border-radius: 8px;
  1084	        overflow: hidden;
  1085	        box-shadow: 0 2px 12px rgba(0, 0, 0, 0.05);
  1086	
  1087	        th, td {
  1088	          padding: 12px 16px;
  1089	          border: 1px solid #e2e8f0;
  1090	          text-align: left;
  1091	        }
  1092	
  1093	        th {
  1094	          background: #f8fafc;
  1095	          font-weight: 600;
  1096	          color: #2c3e50;
  1097	        }
  1098	
  1099	        tr:nth-child(even) {
  1100	          background: #f8fafc;
  1101	        }
  1102	
  1103	        tr:hover {
  1104	          background: #f1f5f9;
  1105	        }
  1106	      }
  1107	    }
  1108	  }
  1109	}
  1110	</style>
```

---

**🧑‍🚒 Response (5)**: 
Now let me check if there are any test files related to drafts to understand what the expected behavior should be:
**👀‍ Observation (5)**:
```

```

---

**🧑‍🚒 Response (6)**: 

**👀‍ Observation (6)**:
```

```

---

**🧑‍🚒 Response (7)**: 
Let me check for any recent commits or changes that might give us a clue about what needs to be optimized:
**👀‍ Observation (7)**:
```
1614dda (grafted, HEAD, origin/main) fix: agent skills
4a5d8f6 (origin/swe-agent-fix-#3-05443802) SWE-agent revise: 通知中心： 全部/评论/回复按钮样式动画优化，颜色不要使用蓝色，需要适é
6494181 Fix: 界面右上角通知中心 消息切换按钮 颜色样式优化
d1e8986 Merge pull request #2 from smartcat999/swe-agent-fix-#1-43631185
75bccd5 (origin/swe-agent-fix-#1-43631185) Fix: 修复一个简单问题
b3cae8e fix: github pr create
82e7c2c fix: github pr create
75c7bad fix: github pr create
611f7c5 fix: github pr create
b6cfde7 fix: github pr create
db05799 fix: github pr create
574c70d fix: swe command error
1a6bf67 fix: swe command error
26216c6 fix: swe command error
6435d8c fix: swe command error
256221a fix: swe command error
ebba3cf fix: swe command error
6fdd554 fix: swe command error
4b2fee1 fix: swe command error
da4011b fix: swe command error
```

---

**🧑‍🚒 Response (8)**: 
Let me check if there are any issues or PR descriptions in the repository:
**👀‍ Observation (8)**:
```
/smartcat999__notex/README.md
/smartcat999__notex/README_SWE_AGENT.md
/smartcat999__notex/.claude/README.md
/smartcat999__notex/.claude/skills/minimal-changes/SKILL.md
/smartcat999__notex/.claude/skills/code-focus/SKILL.md
/smartcat999__notex/frontend/web/src/components/ai/README.md
```

---

**🧑‍🚒 Response (9)**: 
Let me look at similar style optimizations that were done before to understand the pattern:
**👀‍ Observation (9)**:
```
commit 64941819dfcf3c87dad8ceb44a2d4326128a2d4f
Author: SWE-agent <noemail@swe-agent.com>
Date:   Tue Nov 4 05:12:54 2025 +0000

    Fix: 界面右上角通知中心 消息切换按钮 颜色样式优化
    
    Closes #3

 frontend/web/src/components/NotificationCenter.vue | 36 ++++++++++++++++++++++
 1 file changed, 36 insertions(+)
```

---

**🧑‍🚒 Response (10)**: 

**👀‍ Observation (10)**:
```
commit 64941819dfcf3c87dad8ceb44a2d4326128a2d4f
Author: SWE-agent <noemail@swe-agent.com>
Date:   Tue Nov 4 05:12:54 2025 +0000

    Fix: 界面右上角通知中心 消息切换按钮 颜色样式优化
    
    Closes #3

diff --git a/frontend/web/src/components/NotificationCenter.vue b/frontend/web/src/components/NotificationCenter.vue
index 7919409..ecb2359 100644
--- a/frontend/web/src/components/NotificationCenter.vue
+++ b/frontend/web/src/components/NotificationCenter.vue
@@ -187,6 +187,42 @@ onMounted(() => {
     align-items: center;
     justify-content: space-between;
     gap: 12px;
+
+    :deep(.el-radio-group) {
+      .el-radio-button {
+        &:first-child {
+          .el-radio-button__inner {
+            border-radius: 4px 0 0 4px;
+          }
+        }
+        
+        &:last-child {
+          .el-radio-button__inner {
+            border-radius: 0 4px 4px 0;
+          }
+        }
+        
+        .el-radio-button__inner {
+          border-color: var(--el-border-color);
+          color: var(--el-text-color-regular);
+          transition: all 0.2s ease;
+          
+          &:hover {
+            color: var(--el-color-primary);
+            border-color: var(--el-color-primary-light-7);
+          }
+        }
+        
+        &.is-active {
+          .el-radio-button__inner {
+            background: var(--el-color-primary);
+            color: white;
+            border-color: var(--el-color-primary);
+            box-shadow: none;
+          }
+        }
+      }
+    }
   }
 }
```

---

**🧑‍🚒 Response (11)**: 
Now let me look at the current state of the Drafts.vue file more carefully. Based on the PR description, I need to optimize:
1. Search box style (搜索框样式)
2. Draft list style (草稿列表样式)
3. Draft list button style (草稿列表按钮样式)

Looking at the current code, I can see:
- The search box is at lines 6-15 using `el-input`
- The draft list is at lines 19-53 with draft cards
- The draft list buttons are at lines 26-34 with action buttons

Let me check if there are any similar components to understand the styling pattern better:
**👀‍ Observation (11)**:
```
/smartcat999__notex/frontend/web/src/views/Settings.vue
/smartcat999__notex/frontend/web/src/views/Home.vue
/smartcat999__notex/frontend/web/src/views/Posts.vue
/smartcat999__notex/frontend/web/src/views/NotFound.vue
/smartcat999__notex/frontend/web/src/views/UserProfile.vue
/smartcat999__notex/frontend/web/src/views/Tags.vue
/smartcat999__notex/frontend/web/src/views/auth/Login.vue
/smartcat999__notex/frontend/web/src/views/auth/Register.vue
/smartcat999__notex/frontend/web/src/views/Categories.vue
/smartcat999__notex/frontend/web/src/views/NewPost.vue
```

---

**🧑‍🚒 Response (12)**: 
Let me check the Posts.vue to see if there's a similar pattern:
**👀‍ Observation (12)**:
```
12:        <el-input
25:        </el-input>
```

---

**🧑‍🚒 Response (13)**: 

**👀‍ Observation (13)**:
```
Here's the result of running `cat -n` on /smartcat999__notex/frontend/web/src/views/Posts.vue:
     1	<template>
     2	  <div class="posts-page">
     3	    <div class="page-header">
     4	      <div class="title-section">
     5	        <div class="title-wrapper">
     6	          <h1>学习笔记</h1>
     7	          <div class="title-decoration"></div>
     8	        </div>
     9	        <p class="subtitle">记录点滴，分享所得</p>
    10	      </div>
    11	      <div class="header-actions">
    12	        <el-input
    13	          v-model="searchQuery"
    14	          placeholder="搜索文章..."
    15	          class="search-input"
    16	          clearable
    17	          @clear="handleSearch"
    18	        >
    19	          <template #prefix>
    20	            <el-icon><Search /></el-icon>
    21	          </template>
    22	          <template #append>
    23	            <el-button @click="handleSearch">搜索</el-button>
    24	          </template>
    25	        </el-input>
    26	
    27	        <el-select
    28	          v-model="selectedCategory"
    29	          placeholder="选择分类"
    30	          clearable
    31	          @change="handleSearch"
    32	        >
    33	          <el-option
    34	            v-for="category in categories"
    35	            :key="category.id"
    36	            :label="category.name"
    37	            :value="category.id"
    38	          />
    39	        </el-select>
    40	
    41	        <el-select
    42	          v-model="sortBy"
    43	          placeholder="排序方式"
    44	          @change="handleSearch"
    45	        >
    46	          <el-option label="最新发布" value="newest" />
    47	          <el-option label="最多浏览" value="most_viewed" />
    48	          <el-option label="最多评论" value="most_commented" />
    49	        </el-select>
    50	      </div>
    51	    </div>
    52	
    53	    <div class="posts-container">
    54	      <el-row :gutter="24">
    55	        <el-col :span="18">
    56	          <div class="posts-list" v-loading="loading">
    57	            <el-card v-for="post in posts" :key="post.id" class="post-card">
    58	              <div class="post-content">
    59	                <div class="post-main">
    60	                  <h2 class="post-title">
    61	                    <router-link :to="`/posts/${post.id}`">
    62	                      {{ post.title }}
    63	                    </router-link>
    64	                  </h2>
    65	                  <p class="post-summary">{{ post.summary }}</p>
    66	                  <div class="post-meta">
    67	                    <span class="post-date">
    68	                      <el-icon><Calendar /></el-icon>
    69	                      {{ formatDate(post.published_at || post.created_at) }}
    70	                    </span>
    71	                    <span class="post-category" v-if="post.category">
    72	                      <el-icon><Folder /></el-icon>
    73	                      {{ post.category }}
    74	                    </span>
    75	                    <span class="post-views" v-if="post.views !== undefined">
    76	                      <el-icon><View /></el-icon>
    77	                      {{ post.views || 0 }} 次浏览
    78	                    </span>
    79	                  </div>
    80	                </div>
    81	                <div class="post-cover" v-if="post.cover">
    82	                  <img :src="post.cover" :alt="post.title">
    83	                </div>
    84	              </div>
    85	              <div class="post-footer">
    86	                <div class="post-tags" v-if="post.tags && post.tags.length">
    87	                  <el-tag
    88	                    v-for="tag in post.tags"
    89	                    :key="tag.id"
    90	                    size="small"
    91	                    :type="getRandomTagType()"
    92	                    effect="plain"
    93	                  >
    94	                    {{ tag.name }}
    95	                  </el-tag>
    96	                </div>
    97	              </div>
    98	            </el-card>
    99	
   100	            <div class="pagination" v-if="total > 0">
```

---

**🧑‍🚒 Response (14)**: 
Now let me check the styling for the search input in Posts.vue:
**👀‍ Observation (14)**:
```
.search-input {
        width: 300px;
      }

      .el-select {
        width: 140px;
      }
    }
  }

  .posts-container {
    max-width: 900px;
    margin: 0 auto;

    .posts-list {
      .post-card {
        margin-bottom: 32px;
        padding: 32px;
        transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
        border: none;
        border-radius: 10px;
        overflow: hidden;
        padding: 16px;
        background: rgba(255, 255, 255, 0.98);
        box-shadow: 0 2px 12px rgba(0, 0, 0, 0.05);

        &:hover {
          transform: translateY(-2px);
          box-shadow: 0 6px 20px rgba(0, 0, 0, 0.08);
          background: rgba(255, 255, 255, 1);

--
        .search-input {
          width: 100%;
        }
        
        .el-select {
          width: 100%;
        }
      }
    }
    
    .posts-list {
      .post-card {
        padding: 20px;
        
        .post-content {
          flex-direction: column;
          gap: 20px;

          .post-cover {
            order: -1;
            flex: none;
            width: calc(100% + 40px);
            height: 200px;
            margin: -20px -20px 0;
            border-radius: 16px 16px 0 0;
            box-shadow: none;
            
            &:hover {
              transform: none;
              box-shadow: none;
            }
```

---

**🧑‍🚒 Response (15)**: 
Now let me understand what styling improvements are needed. Based on the PR description and looking at similar components, I need to:

1. **Search box style optimization**: Add better styling to the search input with width, border-radius, transitions
2. **Draft list style optimization**: Improve the card styling, shadows, hover effects
3. **Draft list button style optimization**: Improve button styling with better colors, transitions, and hover effects

Looking at the current code, I can see that there's already some styling, but it might need improvements. Let me create a test file first to understand the current state:
**👀‍ Observation (15)**:
```
File created successfully at: /smartcat999__notex/test_drafts_style.md
```

---

**🧑‍🚒 Response (16)**: 
Now let me analyze the current styling more carefully and create the optimized version. Looking at the code, I can see:

1. The search input doesn't have a specific width or class
2. The buttons in draft-actions already have some styling but could be improved
3. The preview button uses `plain` attribute which might not look as good

Let me now create the optimized version:
**👀‍ Observation (16)**:
```
The file /smartcat999__notex/frontend/web/src/views/Drafts.vue has been edited. Here's the result of running `cat -n` on a snippet of /smartcat999__notex/frontend/web/src/views/Drafts.vue:
     1	<template>
     2	  <div class="drafts-container">
     3	    <div class="page-header">
     4	      <h1>草稿箱</h1>
     5	      <div class="header-actions">
     6	        <el-input
     7	          v-model="searchQuery"
     8	          placeholder="搜索草稿..."
     9	          class="search-input"
    10	          @input="handleSearch"
    11	          clearable
    12	        >
    13	          <template #prefix>
    14	            <el-icon><Search /></el-icon>
    15	          </template>
    16	        </el-input>
    17	      </div>
    18	    </div>
    19	
    20	    <div class="drafts-list" v-loading="loading">
    21	      <template v-if="drafts.length > 0">
Review the changes and make sure they are as expected. Edit the file again if necessary.
```

---

**🧑‍🚒 Response (17)**: 
Now let me update the button section to remove the `plain` attribute from the preview button and add icons to other buttons:
**👀‍ Observation (17)**:
```
The file /smartcat999__notex/frontend/web/src/views/Drafts.vue has been edited. Here's the result of running `cat -n` on a snippet of /smartcat999__notex/frontend/web/src/views/Drafts.vue:
    22	        <div v-for="draft in drafts" :key="draft.id" class="draft-card">
    23	          <div class="draft-header">
    24	            <h2 class="draft-title">
    25	              <a :href="draft.url" target="_blank">{{ draft.title || '无标题草稿' }}</a>
    26	            </h2>
    27	            <div class="draft-actions">
    28	              <el-button type="info" @click="handlePreview(draft)">
    29	                <el-icon><View /></el-icon>
    30	                预览
    31	              </el-button>
    32	              <el-button type="primary" @click="handleEdit(draft)">
    33	                <el-icon><Edit /></el-icon>
    34	                编辑
    35	              </el-button>
    36	              <el-button type="success" @click="handlePublish(draft)">
    37	                <el-icon><Upload /></el-icon>
    38	                发布
    39	              </el-button>
    40	              <el-button type="danger" @click="handleDelete(draft)">
    41	                <el-icon><Delete /></el-icon>
    42	                删除
    43	              </el-button>
    44	            </div>
    45	          </div>
    46	          <div class="draft-meta">
    47	            <span class="draft-date">最后编辑: {{ formatDate(draft.updated_at) }}</span>
Review the changes and make sure they are as expected. Edit the file again if necessary.
```

---

**🧑‍🚒 Response (18)**: 
Now I need to add the missing icon imports in the script section:
**👀‍ Observation (18)**:
```
The file /smartcat999__notex/frontend/web/src/views/Drafts.vue has been edited. Here's the result of running `cat -n` on a snippet of /smartcat999__notex/frontend/web/src/views/Drafts.vue:
   135	
   136	<script setup>
   137	import { ref, onMounted, nextTick, watch } from 'vue'
   138	import { useRouter } from 'vue-router'
   139	import { ElMessage, ElMessageBox } from 'element-plus'
   140	import { Search, View, Calendar, ChatDotRound, Edit, Upload, Delete } from '@element-plus/icons-vue'
   141	import { getDrafts, deleteDraft, publishDraft, getDraft } from '@/api/drafts'
   142	import { formatDate } from '@/utils/date'
   143	import { useUserStore } from '@/stores/user'
Review the changes and make sure they are as expected. Edit the file again if necessary.
```

---

**🧑‍🚒 Response (19)**: 
Now let me update the styles section to add better styling for the search input and improve the button styles:
**👀‍ Observation (19)**:
```
The file /smartcat999__notex/frontend/web/src/views/Drafts.vue has been edited. Here's the result of running `cat -n` on a snippet of /smartcat999__notex/frontend/web/src/views/Drafts.vue:
   380	        z-index: -1;
   381	        transform: skew(-12deg);
   382	      }
   383	    }
   384	
   385	    .header-actions {
   386	      display: flex;
   387	      justify-content: center;
   388	      gap: 16px;
   389	      margin-top: 24px;
   390	
   391	      .search-input {
   392	        width: 400px;
   393	        
   394	        :deep(.el-input__wrapper) {
   395	          border-radius: 24px;
   396	          padding: 8px 16px;
   397	          box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
   398	          transition: all 0.3s ease;
   399	          background: rgba(255, 255, 255, 0.98);
   400	          
   401	          &:hover {
   402	            box-shadow: 0 4px 12px rgba(0, 0, 0, 0.12);
   403	          }
   404	          
   405	          &.is-focus {
   406	            box-shadow: 0 4px 16px rgba(43, 88, 118, 0.15);
   407	            border-color: rgba(43, 88, 118, 0.3);
   408	          }
   409	        }
   410	        
   411	        :deep(.el-input__prefix) {
   412	          color: #2B5876;
   413	        }
   414	        
   415	        :deep(.el-input__inner) {
   416	          font-size: 0.95em;
   417	        }
   418	      }
   419	
   420	      .action-button {
   421	        padding: 12px 24px;
   422	        border-radius: 8px;
   423	        transition: all 0.3s ease;
   424	        background: linear-gradient(135deg, #2B5876, #4E4376);
   425	        color: white;
   426	        border: none;
   427	        display: flex;
   428	        align-items: center;
   429	        gap: 8px;
   430	        font-size: 1em;
   431	
   432	        &:hover {
   433	          transform: translateY(-2px);
   434	          box-shadow: 0 4px 12px rgba(43, 88, 118, 0.2);
   435	        }
   436	
   437	        .el-icon {
   438	          font-size: 1.2em;
   439	        }
   440	      }
   441	    }
   442	  }
   443	
   444	  .drafts-list {
Review the changes and make sure they are as expected. Edit the file again if necessary.
```

---

**🧑‍🚒 Response (20)**: 
Now let me improve the draft card styling:
**👀‍ Observation (20)**:
```
The file /smartcat999__notex/frontend/web/src/views/Drafts.vue has been edited. Here's the result of running `cat -n` on a snippet of /smartcat999__notex/frontend/web/src/views/Drafts.vue:
   439	        }
   440	      }
   441	    }
   442	  }
   443	
   444	  .drafts-list {
   445	    .draft-card {
   446	      background: rgba(255, 255, 255, 0.98);
   447	      border-radius: 16px;
   448	      box-shadow: 0 2px 12px rgba(0, 0, 0, 0.06);
   449	      padding: 28px;
   450	      margin-bottom: 24px;
   451	      transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
   452	      border: 1px solid rgba(43, 88, 118, 0.08);
   453	
   454	      &:hover {
   455	        transform: translateY(-4px);
   456	        box-shadow: 0 8px 24px rgba(0, 0, 0, 0.1);
   457	        background: rgba(255, 255, 255, 1);
   458	        border-color: rgba(43, 88, 118, 0.15);
   459	      }
   460	
   461	      .draft-header {
   462	        display: flex;
Review the changes and make sure they are as expected. Edit the file again if necessary.
```

... (truncated due to length limit)
</details>